### PR TITLE
Update mover to work with PostgreSQL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ pkg
 spec/config/database.yml
 spec/log
 tmp
+.rvmrc

--- a/config/gemsets.yml
+++ b/config/gemsets.yml
@@ -2,4 +2,4 @@ mover:
   rake: >=0.8.7
   rspec: ~>1.0
   default:
-    active_wrapper: =0.4.3
+    active_wrapper: =0.4.4

--- a/spec/mover_spec.rb
+++ b/spec/mover_spec.rb
@@ -9,6 +9,9 @@ describe Mover do
       before(:all) do
         @options = {}
         @options[option] = true
+        $db.drop_db
+        $db.create_db
+        $db.establish_connection
       end
     
       before(:each) do


### PR DESCRIPTION
Hi Winton,

This changeset should enable acts_as_archive to work under Postgres as the specs now pass using the postgresql adapter.
