### PR TITLE
move across dbs

### DIFF
--- a/lib/mover.rb
+++ b/lib/mover.rb
@@ -39,6 +39,7 @@ module Mover
         :table => from_class.table_name
       }
       to = {
+        :database => to_class.connection.current_database,
         :columns => to_class.column_names,
         :table => to_class.table_name
       }
@@ -104,7 +105,7 @@ module Mover
         
         if options[:quick]
           connection.execute(<<-SQL)
-            INSERT INTO #{to[:table]} (#{insert.keys.join(', ')})
+            INSERT INTO #{to[:database]}.#{to[:table]} (#{insert.keys.join(', ')})
             SELECT #{insert.values.join(', ')}
             FROM #{from[:table]}
             #{where}
@@ -117,9 +118,8 @@ module Mover
               "#{to[:table]}.#{column} = #{from[:table]}.#{value}"
             end
           end
-          
           connection.execute(<<-SQL)
-            INSERT INTO #{to[:table]} (#{insert.keys.join(', ')})
+            INSERT INTO #{ to[:database]}.#{to[:table]} (#{insert.keys.join(', ')})
             SELECT #{insert.values.join(', ')}
             FROM #{from[:table]}
             #{where}


### PR DESCRIPTION
Hey guys,
I updated mover to be able to move data across databases. In the event that someone has an AR class that uses a different db connection this should allow mover to move the data to the right db (provided it's on the same machine)
